### PR TITLE
Remove .exe when searching for process

### DIFF
--- a/RemoteWindowsMediaPlayer/WindowsMediaPlayerController.cs
+++ b/RemoteWindowsMediaPlayer/WindowsMediaPlayerController.cs
@@ -55,7 +55,7 @@ namespace MediaPlayerController
 
     public bool IsWMPRunning()
     {
-      return   Process.GetProcessesByName("wmplayer.exe").Length > 0;
+      return   Process.GetProcessesByName("wmplayer").Length > 0;
     }
 
     public void OpenMediaPlayer()


### PR DESCRIPTION
Windows now reports the process without `.exe` at the end of it, so the current code doesn't work anymore. Removing `.exe` when searching for `wmplayer` gets it working again.